### PR TITLE
added delete_user

### DIFF
--- a/app/resources/service.py
+++ b/app/resources/service.py
@@ -218,11 +218,12 @@ def hardware_delete(data: dict, microservice: str) -> dict:
 
 
 @m.microservice_endpoint(path=["delete_user"])
-def delete_user(data: dict) -> dict:
+def delete_user(data: dict, microservice: str) -> dict:
     """
     Delete all devices of a user.
 
     :param data: The given data.
+    :param microservice: The name of the requesting microservice
     :return: Success or not
     """
     user_uuid: str = data["user_uuid"]

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -77,6 +77,7 @@ class TestApp(TestCase):
             ["hardware", "delete"],
             ["miner", "stop"],
             ["miner", "collect"],
+            ["delete_user"],
         ]
 
         for path, requires in expected_user_endpoints:


### PR DESCRIPTION
This endpoint is used to delete all services used by a specific user.

## Description
- delete bruteforce if service if bruteforce
- delete miner if server is miner
- delete service itself

## Related Issue
#46 

## Motivation and Context
Create an endpoint for deleting complete users, and their related data.

## How Has This Been Tested?
not yet tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
