### PR TITLE
changed creator of service from controlling user to owner of device 

### DIFF
--- a/app/resources/essentials.py
+++ b/app/resources/essentials.py
@@ -44,9 +44,7 @@ def change_miner_power(power: float, service_uuid: str, device_uuid: str, user: 
 
 
 def controls_device(device: str, user: str) -> bool:
-    return m.contact_microservice("device", ["owner"], {"device_uuid": device}).get(
-        "owner"
-    ) == user or game_content.part_owner(device, user)
+    return get_device_owner(device) == user or game_content.part_owner(device, user)
 
 
 def get_device_owner(device: str) -> str:

--- a/app/resources/essentials.py
+++ b/app/resources/essentials.py
@@ -49,6 +49,10 @@ def controls_device(device: str, user: str) -> bool:
     ) == user or game_content.part_owner(device, user)
 
 
+def get_device_owner(device: str) -> str:
+    return m.contact_microservice("device", ["owner"], {"device_uuid": device}).get("owner")
+
+
 def exists_wallet(wallet: str) -> bool:
     return m.contact_microservice("currency", ["exists"], {"source_uuid": wallet})["exists"]
 

--- a/app/resources/service.py
+++ b/app/resources/service.py
@@ -163,13 +163,13 @@ def create(data: dict, user: str) -> dict:
     if not controls_device(device_uuid, user):
         return permission_denied
 
+    device_owner: str = get_device_owner(device_uuid)
     service_count: int = wrapper.session.query(func.count(Service.name)).filter_by(
-        owner=user, device=device_uuid, name=name
+        owner=device_owner, device=device_uuid, name=name
     ).scalar()
     if service_count != 0:
         return already_own_this_service
 
-    device_owner: str = get_device_owner(device_uuid)
     return create_service(name, data, device_owner)
 
 

--- a/app/resources/service.py
+++ b/app/resources/service.py
@@ -15,6 +15,7 @@ from resources.essentials import (
     delete_one_service,
     stop_service,
     register_service,
+    get_device_owner,
 )
 from schemes import (
     service_not_found,
@@ -168,7 +169,8 @@ def create(data: dict, user: str) -> dict:
     if service_count != 0:
         return already_own_this_service
 
-    return create_service(name, data, user)
+    device_owner: str = get_device_owner(device_uuid)
+    return create_service(name, data, device_owner)
 
 
 @m.user_endpoint(path=["part_owner"], requires=device_scheme)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The owner of a new service should be the owner of the device. On hacked devices, the hacker was the owner of services he created on that device, this fixes that.

## Description
- added get_device_owner in service.py
- changed user from controlling user to device owner, returned by function mentioned above

## Related Issue
#47 

## Motivation and Context
Bugfix: To make sure, that the owner of a new created service is the owner of the devices the service is running on.

## How Has This Been Tested?
not yet tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
