### PR TITLE
added miner stop endpoint to stop miner when associated wallet is deleted (#50)

### DIFF
--- a/app/resources/miner.py
+++ b/app/resources/miner.py
@@ -3,7 +3,7 @@ import time
 from app import m, wrapper
 from models.miner import Miner
 from models.service import Service
-from resources.essentials import exists_device, controls_device, exists_wallet, update_miner, change_miner_power
+from resources.essentials import exists_device, controls_device, exists_wallet, update_miner, change_miner_power, stop_service
 from schemes import (
     miner_not_found,
     device_not_found,
@@ -54,6 +54,23 @@ def set_wallet(data: dict, user: str) -> dict:
     wrapper.session.commit()
 
     return miner.serialize
+
+
+@m.microservice_endpoint(path=["miner", "stop"])
+def toggle(data: dict) -> dict:
+    miner_list: list = wrapper.session.query(Miner).filter_by(wallet=data["wallet_uuid"])
+    if not miner_list:
+        return miner_not_found
+    for miner in miner_list:
+        service: Service = wrapper.session.query(Service).filter_by(uuid=miner.uuid).first()
+
+        if service.running:
+            stop_service(service.device, service.uuid, service.owner)
+
+        service.running = False
+        wrapper.session.commit()
+
+        return service.serialize
 
 
 @m.user_endpoint(path=["miner", "power"], requires=miner_set_power_scheme)

--- a/app/resources/miner.py
+++ b/app/resources/miner.py
@@ -3,7 +3,14 @@ import time
 from app import m, wrapper
 from models.miner import Miner
 from models.service import Service
-from resources.essentials import exists_device, controls_device, exists_wallet, update_miner, change_miner_power, stop_service
+from resources.essentials import (
+    exists_device,
+    controls_device,
+    exists_wallet,
+    update_miner,
+    change_miner_power,
+    stop_service,
+)
 from schemes import (
     miner_not_found,
     device_not_found,
@@ -14,6 +21,7 @@ from schemes import (
     miner_set_wallet_scheme,
     miner_set_power_scheme,
     could_not_start_service,
+    success_scheme,
 )
 
 
@@ -56,23 +64,6 @@ def set_wallet(data: dict, user: str) -> dict:
     return miner.serialize
 
 
-@m.microservice_endpoint(path=["miner", "stop"])
-def toggle(data: dict) -> dict:
-    miner_list: list = wrapper.session.query(Miner).filter_by(wallet=data["wallet_uuid"])
-    if not miner_list:
-        return miner_not_found
-    for miner in miner_list:
-        service: Service = wrapper.session.query(Service).filter_by(uuid=miner.uuid).first()
-
-        if service.running:
-            stop_service(service.device, service.uuid, service.owner)
-
-        service.running = False
-        wrapper.session.commit()
-
-        return service.serialize
-
-
 @m.user_endpoint(path=["miner", "power"], requires=miner_set_power_scheme)
 def set_power(data: dict, user: str) -> dict:
     service_uuid: str = data["service_uuid"]
@@ -108,6 +99,21 @@ def set_power(data: dict, user: str) -> dict:
     wrapper.session.commit()
 
     return miner.serialize
+
+
+@m.microservice_endpoint(path=["miner", "stop"])
+def miner_stop(data: dict, microservice: str) -> dict:
+    for miner in wrapper.session.query(Miner).filter_by(wallet=data["wallet_uuid"]):
+        service: Service = wrapper.session.query(Service).filter_by(uuid=miner.uuid).first()
+
+        if service.running:
+            stop_service(service.device, service.uuid, service.owner)
+
+        service.running = False
+
+    wrapper.session.commit()
+
+    return success_scheme
 
 
 @m.microservice_endpoint(path=["miner", "collect"])

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -75,6 +75,7 @@ class TestApp(TestCase):
             ["hardware", "scale"],
             ["hardware", "stop"],
             ["hardware", "delete"],
+            ["miner", "stop"],
             ["miner", "collect"],
         ]
 


### PR DESCRIPTION
added miner stop endpoint

## Related Issue
#50 

## Motivation and Context
create possibility to stop miner if associated wallet is deleted

## How Has This Been Tested?
not yet tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
